### PR TITLE
README: fix clone URL to use HTTPS

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -37,7 +37,7 @@ or clone it and install it:
 
 .. code-block:: bash
 
-    $ git clone http://github.com/pyexcel/pyexcel-xlsx.git
+    $ git clone https://github.com/pyexcel/pyexcel-xlsx.git
     $ cd pyexcel-xlsx
     $ python setup.py install
 


### PR DESCRIPTION
Prevent a git warning: `warning: redirecting to https://github.com/pyexcel/pyexcel-xlsx.git/`