### PR TITLE
replace Deprecated method `merged_cell_ranges`

### DIFF
--- a/pyexcel_xlsx/xlsxr.py
+++ b/pyexcel_xlsx/xlsxr.py
@@ -41,10 +41,9 @@ class FastSheet(SheetReader):
 
 
 class MergedCell(object):
-    def __init__(self, cell_ranges_str):
-        topleft, bottomright = cell_ranges_str.split(':')
-        self.__rl, self.__cl = convert_coordinate(topleft)
-        self.__rh, self.__ch = convert_coordinate(bottomright)
+    def __init__(self, cell_ranges):
+        self.__rl, self.__cl = cell_ranges.bounds[:2]
+        self.__rh, self.__ch = cell_ranges.bounds[2:]
         self.value = None
 
     def register_cells(self, registry):

--- a/pyexcel_xlsx/xlsxr.py
+++ b/pyexcel_xlsx/xlsxr.py
@@ -78,7 +78,7 @@ class SlowSheet(FastSheet):
         self.max_column = 0
         self.__sheet_max_row = sheet.max_row
         self.__sheet_max_column = sheet.max_column
-        for ranges_str in sheet.merged_cell_ranges:
+        for ranges_str in sheet.merged_cells.ranges:
             merged_cells = MergedCell(ranges_str)
             merged_cells.register_cells(self.__merged_cells)
             if self.max_row < merged_cells.bottom_row():

--- a/pyexcel_xlsx/xlsxr.py
+++ b/pyexcel_xlsx/xlsxr.py
@@ -77,7 +77,7 @@ class SlowSheet(FastSheet):
         self.max_column = 0
         self.__sheet_max_row = sheet.max_row
         self.__sheet_max_column = sheet.max_column
-        for ranges_str in sheet.merged_cells.ranges:
+        for ranges_str in sheet.merged_cells.ranges[:]:
             merged_cells = MergedCell(ranges_str)
             merged_cells.register_cells(self.__merged_cells)
             if self.max_row < merged_cells.bottom_row():


### PR DESCRIPTION
`merged_cell_ranges` is replaced by `merged_cells.ranges`
link: http://openpyxl.readthedocs.io/en/default/_modules/openpyxl/worksheet/worksheet.html