### PR TITLE
Improve sample codes about json.dumps usage

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -136,7 +136,7 @@ Here's the sample code:
     >>> from pyexcel_xlsx import get_data
     >>> data = get_data("your_file.xlsx")
     >>> import json
-    >>> print(json.dumps(data))
+    >>> print(json.dumps(data, default=str))
     {"Sheet 1": [[1, 2, 3], [4, 5, 6]], "Sheet 2": [["row 1", "row 2", "row 3"]]}
 
 
@@ -171,7 +171,7 @@ Continue from previous example:
     >>> # In reality, you might deal with xlsx file upload
     >>> # where you will read from requests.FILES['YOUR_XLSX_FILE']
     >>> data = get_data(io)
-    >>> print(json.dumps(data))
+    >>> print(json.dumps(data, default=str))
     {"Sheet 1": [[1, 2, 3], [4, 5, 6]], "Sheet 2": [[7, 8, 9], [10, 11, 12]]}
 
 
@@ -202,7 +202,7 @@ And let's pretend to read partial data:
 .. code-block:: python
 
    >>> partial_data = get_data("huge_file.xlsx", start_row=2, row_limit=3)
-   >>> print(json.dumps(partial_data))
+   >>> print(json.dumps(partial_data, default=str))
    {"huge": [[3, 23, 33], [4, 24, 34], [5, 25, 35]]}
 
 And you could as well do the same for columns:
@@ -210,7 +210,7 @@ And you could as well do the same for columns:
 .. code-block:: python
 
    >>> partial_data = get_data("huge_file.xlsx", start_column=1, column_limit=2)
-   >>> print(json.dumps(partial_data))
+   >>> print(json.dumps(partial_data, default=str))
    {"huge": [[21, 31], [22, 32], [23, 33], [24, 34], [25, 35], [26, 36]]}
 
 Obvious, you could do both at the same time:
@@ -220,7 +220,7 @@ Obvious, you could do both at the same time:
    >>> partial_data = get_data("huge_file.xlsx",
    ...     start_row=2, row_limit=3,
    ...     start_column=1, column_limit=2)
-   >>> print(json.dumps(partial_data))
+   >>> print(json.dumps(partial_data, default=str))
    {"huge": [[23, 33], [24, 34], [25, 35]]}
 
 .. testcode::


### PR DESCRIPTION
With your PR, here is a check list:

- [ ] Has test cases written?
- [ ] Has all code lines tested?
- [ ] Has `make format` been run?
- [ ] Please update CHANGELOG.yml(not CHANGELOG.rst)
- [X] Has fair amount of documentation if your change is complex
- [X] Agree on NEW BSD License for your contribution

Sometimes it will throw the `"datetime.datetime not JSON serializable"?` exception error when using the `json.dumps` method.
To avoid throwing the above exception message, it should add the `default` parameter with the `str` value. And it can be great to use `json.dumps` method without throwing the exception message.